### PR TITLE
Added get_window_size method to class world 

### DIFF
--- a/resources/gui.py
+++ b/resources/gui.py
@@ -7,6 +7,7 @@ from kivy.uix.dropdown import DropDown
 from kivy.graphics import Rectangle, Color, Ellipse
 from kivy.core.window import Window
 from kivy.clock import Clock
+from world import World
 
 # import kivy
 # from kivy.config import Config
@@ -171,6 +172,10 @@ class ButtonWidget(BoxLayout):
     def change_window_size(self, window_size):
         Window.size = window_size
         Clock.schedule_once(lambda dt: self.simulation_widget.update_canvas(), 0.1)
+        
+        #To inform the 'World' class about the current size of the GUI window...
+        world_instance = World()
+        world_instance.get_window_size(window_size)
 
 
 

--- a/resources/world.py
+++ b/resources/world.py
@@ -15,3 +15,7 @@ class World:
 
     def generate_obstacles(self):
         pass
+
+    def get_window_size(self, window_size):       
+        self.width, self.height = window_size[0], window_size[1]
+        return window_size


### PR DESCRIPTION
In the "World" class (world.py), I added a method called get_window_size that allows updating the width and height of the world object based on the passed window size.

In the "ButtonWidget" class (gui.py), within the "change_window_size" method, I created an instance of the "World" class. Using this instance, I called the get_window_size method and passed the current window size as a parameter.