### PR TITLE
Changes regarding pheromone

### DIFF
--- a/resources/gui.py
+++ b/resources/gui.py
@@ -485,7 +485,8 @@ class ButtonWidget(BoxLayout):
             with self.simulation_widget.canvas:
                 Image(source="../images/colony.png", pos=(transformed_touch[0] - 50, transformed_touch[1] - 50), size=(100, 100))
             self.simulation_widget.unbind(on_touch_down=self.place_colony)
-            sim.add_colony(Colony(grid_pheromone_shape=(100, 100), amount=100, size=(100, 100),
+            n_row, n_col = int(sim.bounds[3]-sim.bounds[2]), int(sim.bounds[1]-sim.bounds[0])
+            sim.add_colony(Colony(grid_pheromone_shape=(n_row, n_col), amount=100, size=(100, 100),
                                   coordinates=(transformed_touch[0] - 50, transformed_touch[1] - 50), color=(0, 0, 0, 1)))
 
 

--- a/test/test_pheromone.py
+++ b/test/test_pheromone.py
@@ -55,8 +55,7 @@ def test_reduce_pheromones():
     assert levels == {'coming from colony': - 0.25, 'coming from food': 0.25}
 
     # Further reductions
-    for _ in range(5):
-        pheromone.reduce_pheromones(reducing_factor = 0.5)
+    pheromone.reduce_pheromones(reducing_factor = 0.5**5)
     levels = pheromone.get_pheromone_level(pos)
     assert levels == {'coming from colony': 0, 'coming from food': 0}
 


### PR DESCRIPTION
- I changed the attribute name `Pheromone.pheromones` to `Pheromone.pheromone_array` for clearer distinction when accessed externally. This avoids confusion.

- When creating a Colony object, a corresponding Pheromone object is now automatically initialized. This allows direct access from a Colony instance to the Pheromone object in simulations, for example, using `colony.pheromone`.