### PR TITLE
Improved popup designs + added pheromone visualization

### DIFF
--- a/resources/colony.py
+++ b/resources/colony.py
@@ -3,7 +3,7 @@ from resources.pheromone import Pheromone
 
 
 class Colony:
-    def __init__(self, grid_pheromone_shape, amount, size, coordinates, color):
+    def __init__(self, grid_pheromone_shape, amount, size, coordinates, color, show_pheromone=False):
         """
         This class represents the Ant-colony.
 
@@ -22,6 +22,7 @@ class Colony:
         self.size = size
         self.coordinates = coordinates
         self.color = color
+        self.show_pheromone = show_pheromone
         self.ants = []
         self.add_ants()
         self.food_counter = 0

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -199,15 +199,17 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
 
             for colony in sim.colonies:
                 pheromone_shape = colony.pheromone.pheromone_array[0].shape
+                scale = (sim.bounds[1]//pheromone_shape[1], -sim.bounds[2]//pheromone_shape[0])
+                print(scale)
                 for pheromone_array in (0, 1):
                     array_values = colony.pheromone.pheromone_array[pheromone_array]
                     # print(array_values)
                     for row in range(pheromone_shape[0]):
                         for col in range(pheromone_shape[1]):
-                            alpha = array_values[row, col] / (255.0*10)
+                            alpha = array_values[row, col] / (255.0*5)
                             color = (0, 0, 0.7, -alpha) if pheromone_array == 0 else (0.7, 0, 0, alpha)
                             Color(*color)
-                            Ellipse(pos=(col*40, -row*(40)-50), size=(50, 50))
+                            Ellipse(pos=(col*scale[0], -row*(scale[1]) - scale[1]), size=(scale[0], scale[1]))
     
             for food in sim.food:
                 Image(source="../images/apple.png", pos=food.coordinates, size=(100, 100))
@@ -217,45 +219,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
                 Color(*colony.color)
                 for ant in colony.ants:
                     Ellipse(pos=ant.coordinates,
-                            size=(5, 5))
-            
-            # Color(0.5, 0, 0, 0.2)
-            # Ellipse(pos=(5, 5), size=(20, 20))
-                    
-        # with self.canvas:
-        #     for colony in sim.colonies:
-        #         pheromone_shape = colony.pheromone.pheromone_array[0].shape
-        #         max_vertices = 65535  # Maximum vertices supported by unsigned short indices
-
-        #         vertices = []
-        #         indices = []
-        #         colors = []
-
-        #         for pheromone_array in (0, 1):
-                    
-        #             array_values = colony.pheromone.pheromone_array[pheromone_array]
-
-        #             for row in range(pheromone_shape[0]):
-        #                 for col in range(pheromone_shape[1]):
-        #                     x = col *2# Adjust for the size of Ellipse
-        #                     y = row  *2# Adjust for the size of Ellipse
-        #                     vertices.extend([x, -y])
-
-        #                     # Only add an index if it's within the allowed range
-        #                     if len(vertices) // 2 - 1 < max_vertices:
-        #                         indices.append(len(vertices) // 2 - 1)
-
-        #                     # Calculate alpha based on cell values
-        #                     alpha = array_values[row, col] / 255.0
-        #                     color = (0, 0, 0.7, alpha) if pheromone_array == 0 else (0.7, 0, 0, alpha)  # Assuming values in the range [0, 255]
-        #                     colors.extend(color)  # Set alpha value in color
-                            
-
-        #         Mesh(vertices=vertices, indices=indices, colors=colors, mode='points')
-                    
-        
-            
-                    
+                            size=(5, 5))                
 
     def update_world(self, dt):
         if self.is_running:
@@ -544,7 +508,7 @@ class ButtonWidget(BoxLayout):
             with self.simulation_widget.canvas:
                 Image(source="../images/colony.png", pos=(transformed_touch[0] - 50, transformed_touch[1] - 50), size=(100, 100))
             self.simulation_widget.unbind(on_touch_down=self.place_colony)
-            n_row, n_col = int(sim.bounds[3]-sim.bounds[2]), int(sim.bounds[1]-sim.bounds[0])
+            n_row, n_col = int(sim.bounds[3]-sim.bounds[2])//40, int(sim.bounds[1]-sim.bounds[0])//40   ### /40 for pheromone grid
             sim.add_colony(Colony(grid_pheromone_shape=(n_row, n_col), amount=100, size=(100, 100),
                                   coordinates=(transformed_touch[0] - 50, transformed_touch[1] - 50), color=(0, 0, 0, 1)))
 

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -196,7 +196,9 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
         self.canvas.clear()
         self.draw_bounds()
         with self.canvas:
-
+            for food in sim.food:
+                Image(source="../images/apple.png", pos=food.coordinates, size=(100, 100))
+            
             for colony in sim.colonies:
                 pheromone_shape = colony.pheromone.pheromone_array[0].shape
                 scale = (sim.bounds[1]//pheromone_shape[1], -sim.bounds[2]//pheromone_shape[0])
@@ -208,11 +210,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
                             color = (0, 0, 0.7, -alpha) if pheromone_array == 0 else (0.7, 0, 0, alpha)
                             Color(*color)
                             Rectangle(pos=(col*scale[0], -row*(scale[1]) - scale[1]), size=(scale[0], scale[1]))
-    
-            for food in sim.food:
-                Image(source="../images/apple.png", pos=food.coordinates, size=(100, 100))
-            
-            for colony in sim.colonies:
+
                 Image(source="../images/colony.png", pos=colony.coordinates, size=(100, 100))
                 Color(*colony.color)
                 for ant in colony.ants:

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -210,7 +210,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
                             alpha = array_values[row, col] / (np.min(array_values)*1.7+1) if pheromone_array == 0 else array_values[row, col] / (np.max(array_values)*1.7+1)
                             color = (0, 0, 0.7, alpha) if pheromone_array == 0 else (0.7, 0, 0, alpha)
                             Color(*color)
-                            Rectangle(pos=(col*scale[0], -row*(scale[1]) - scale[1]), size=(scale[0], scale[1]))
+                            Rectangle(pos=(col*scale[0]+2.5, -row*(scale[1]) - scale[1]+2.5), size=(scale[0], scale[1]))
 
                 Image(source="../images/colony.png", pos=colony.coordinates, size=(100, 100))
                 Color(*colony.color)

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -1,4 +1,5 @@
 import ast
+import numpy as np
 from resources import config
 from kivymd.app import MDApp
 from kivy.uix.widget import Widget
@@ -190,7 +191,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
                 max_y - min_y + 5
             ), width=1)
             pos = (min_x, min_y)
-            Image(source="../images/background.jpg", pos=pos, size=(max_x-min_x+5, max_y-min_y+5), allow_stretch = True, keep_ratio=False)
+            self.img = Image(source="../images/background.jpg", pos=pos, size=(max_x-min_x+5, max_y-min_y+5), allow_stretch = True, keep_ratio=False)
 
     def update_canvas(self):
         self.canvas.clear()
@@ -206,8 +207,8 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
                     array_values = colony.pheromone.pheromone_array[pheromone_array]
                     for row in range(pheromone_shape[0]):
                         for col in range(pheromone_shape[1]):
-                            alpha = array_values[row, col] / (255.0)
-                            color = (0, 0, 0.7, -alpha) if pheromone_array == 0 else (0.7, 0, 0, alpha)
+                            alpha = array_values[row, col] / (np.min(array_values)*1.7+1) if pheromone_array == 0 else array_values[row, col] / (np.max(array_values)*1.7+1)
+                            color = (0, 0, 0.7, alpha) if pheromone_array == 0 else (0.7, 0, 0, alpha)
                             Color(*color)
                             Rectangle(pos=(col*scale[0], -row*(scale[1]) - scale[1]), size=(scale[0], scale[1]))
 

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -2,6 +2,7 @@ import ast
 import numpy as np
 from resources import config
 from kivymd.app import MDApp
+from kivy.uix.label import Label
 from kivy.uix.widget import Widget
 from kivy.uix.boxlayout import BoxLayout
 from kivymd.uix.screen import MDScreen
@@ -14,6 +15,7 @@ from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.button import MDFlatButton
 from kivymd.uix.dialog import MDDialog
 from kivymd.uix.textfield import MDTextField
+from kivy.uix.checkbox import CheckBox
 from kivy.graphics import Rectangle, Color, Ellipse
 from kivy.graphics.transformation import Matrix
 from kivy.graphics import Line
@@ -98,7 +100,7 @@ class GUI(MDApp):
 
     def on_window_resize(self, *args):
         Clock.schedule_interval(lambda instance: self.root.children[1].children[0].adjust_view(instance), 0.2)
-        
+
 
 class ResizableDraggablePicture(Scatter):
     def on_touch_down(self, touch):
@@ -196,6 +198,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
     def update_canvas(self):
         self.canvas.clear()
         self.draw_bounds()
+        self.update_pheromone_checkbox()
         with self.canvas:
             for food in sim.food:
                 Image(source="../images/apple.png", pos=food.coordinates, size=(100, 100))
@@ -211,6 +214,8 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
                         for col in range(pheromone_shape[1]):
                             Color(*color, alpha[row][col])
                             Rectangle(pos=(col*scale[0]+2.5, -row*(scale[1]) - scale[1]+2.5), size=(scale[0], scale[1]))
+                            ## maybe numpy array Rectangle objects, oder Liste
+                            ## pheromone drawing check box neben Canvas
 
                 Image(source="../images/colony.png", pos=colony.coordinates, size=(100, 100))
                 Color(*colony.color)
@@ -229,7 +234,9 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
     def toggle_simulation(self, instance):
         self.is_running = not self.is_running
         instance.text = 'Stop' if self.is_running else 'Start'
-
+        if self.is_running:
+            self.update_pheromone_checkbox()
+            
     def clear_canvas(self, instance):
         sim.food = []
         sim.colonies= []
@@ -335,7 +342,13 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
             return False
         self.scale = 1
         self.pos = ((self.width - sim.bounds[1])//2, (self.height - sim.bounds[2])//2)
-
+    
+    def update_pheromone_checkbox(self, *args):
+        checkboxes = MDBoxLayout(id="checkboxes", orientation="vertical", pos=(sim.bounds[1] + 50, sim.bounds[2]//2), spacing="25dp")
+        checkboxes.add_widget(Label(text="Show\npheromone grid"))
+        for colony in sim.colonies:
+            checkboxes.add_widget(CheckBox(size=(100, 100), active=True, pos_hint={'center_x': .5, 'center_y': 0.5}))
+        self.add_widget(checkboxes)
 
 class FoodButton(MDFloatingActionButton):
     def __init__(self, *args, **kwargs):

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -200,16 +200,14 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
             for colony in sim.colonies:
                 pheromone_shape = colony.pheromone.pheromone_array[0].shape
                 scale = (sim.bounds[1]//pheromone_shape[1], -sim.bounds[2]//pheromone_shape[0])
-                print(scale)
                 for pheromone_array in (0, 1):
                     array_values = colony.pheromone.pheromone_array[pheromone_array]
-                    # print(array_values)
                     for row in range(pheromone_shape[0]):
                         for col in range(pheromone_shape[1]):
-                            alpha = array_values[row, col] / (255.0*5)
+                            alpha = array_values[row, col] / (255.0)
                             color = (0, 0, 0.7, -alpha) if pheromone_array == 0 else (0.7, 0, 0, alpha)
                             Color(*color)
-                            Ellipse(pos=(col*scale[0], -row*(scale[1]) - scale[1]), size=(scale[0], scale[1]))
+                            Rectangle(pos=(col*scale[0], -row*(scale[1]) - scale[1]), size=(scale[0], scale[1]))
     
             for food in sim.food:
                 Image(source="../images/apple.png", pos=food.coordinates, size=(100, 100))

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -263,7 +263,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
             ant_settings_label = MDTextField(hint_text="Step size", text=str(colony.ants[0].step_size))
             carry_label = MDTextField(hint_text="Amount to carry", text=str(colony.ants[0].amount_to_carry))
             color_label = MDTextField(hint_text="Color", text=str(colony.color))
-            show_pheromone_label = MDBoxLayout(orientation="horizontal", size_hint=(.5, .5))
+            show_pheromone_label = MDBoxLayout(orientation="horizontal", size_hint=(.75, .75))
             pheromone_grid_label = MDTextField(hint_text="Pheromone grid", text=str(colony.pheromone.pheromone_array[0].shape))
             pheromone_switch = MDSwitch(icon_active="check")
             show_pheromone_label.add_widget(pheromone_grid_label)

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -13,7 +13,7 @@ from kivy.uix.textinput import TextInput
 from kivymd.uix.button import MDFloatingActionButton
 from kivymd.uix.button import MDFloatingActionButtonSpeedDial
 from kivymd.uix.button import MDFillRoundFlatButton
-from kivy.graphics import Rectangle, Color, Ellipse
+from kivy.graphics import Rectangle, Color, Ellipse, Mesh
 from kivy.graphics.transformation import Matrix
 from kivy.graphics import Line
 from kivy.core.window import Window
@@ -196,17 +196,66 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
         self.canvas.clear()
         self.draw_bounds()
         with self.canvas:
-            for colony in sim.colonies:
-                Image(source="../images/colony.png", pos=colony.coordinates, size=(100, 100))
 
+            for colony in sim.colonies:
+                pheromone_shape = colony.pheromone.pheromone_array[0].shape
+                for pheromone_array in (0, 1):
+                    array_values = colony.pheromone.pheromone_array[pheromone_array]
+                    # print(array_values)
+                    for row in range(pheromone_shape[0]):
+                        for col in range(pheromone_shape[1]):
+                            alpha = array_values[row, col] / (255.0*10)
+                            color = (0, 0, 0.7, -alpha) if pheromone_array == 0 else (0.7, 0, 0, alpha)
+                            Color(*color)
+                            Ellipse(pos=(col*40, -row*(40)-50), size=(50, 50))
+    
             for food in sim.food:
                 Image(source="../images/apple.png", pos=food.coordinates, size=(100, 100))
             
             for colony in sim.colonies:
+                Image(source="../images/colony.png", pos=colony.coordinates, size=(100, 100))
                 Color(*colony.color)
                 for ant in colony.ants:
                     Ellipse(pos=ant.coordinates,
                             size=(5, 5))
+            
+            # Color(0.5, 0, 0, 0.2)
+            # Ellipse(pos=(5, 5), size=(20, 20))
+                    
+        # with self.canvas:
+        #     for colony in sim.colonies:
+        #         pheromone_shape = colony.pheromone.pheromone_array[0].shape
+        #         max_vertices = 65535  # Maximum vertices supported by unsigned short indices
+
+        #         vertices = []
+        #         indices = []
+        #         colors = []
+
+        #         for pheromone_array in (0, 1):
+                    
+        #             array_values = colony.pheromone.pheromone_array[pheromone_array]
+
+        #             for row in range(pheromone_shape[0]):
+        #                 for col in range(pheromone_shape[1]):
+        #                     x = col *2# Adjust for the size of Ellipse
+        #                     y = row  *2# Adjust for the size of Ellipse
+        #                     vertices.extend([x, -y])
+
+        #                     # Only add an index if it's within the allowed range
+        #                     if len(vertices) // 2 - 1 < max_vertices:
+        #                         indices.append(len(vertices) // 2 - 1)
+
+        #                     # Calculate alpha based on cell values
+        #                     alpha = array_values[row, col] / 255.0
+        #                     color = (0, 0, 0.7, alpha) if pheromone_array == 0 else (0.7, 0, 0, alpha)  # Assuming values in the range [0, 255]
+        #                     colors.extend(color)  # Set alpha value in color
+                            
+
+        #         Mesh(vertices=vertices, indices=indices, colors=colors, mode='points')
+                    
+        
+            
+                    
 
     def update_world(self, dt):
         if self.is_running:

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -15,11 +15,13 @@ from kivymd.uix.button import MDFlatButton
 from kivymd.uix.dialog import MDDialog
 from kivymd.uix.textfield import MDTextField
 from kivymd.uix.selectioncontrol import MDSwitch
+from kivy.animation import Animation
 from kivy.graphics import Rectangle, Color, Ellipse
 from kivy.graphics.transformation import Matrix
 from kivy.graphics import Line
 from kivy.core.window import Window
 from kivy.clock import Clock
+from kivy.metrics import dp
 from resources.simulation import Simulation
 from resources.food import Food
 from resources.colony import Colony
@@ -265,7 +267,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
             color_label = MDTextField(hint_text="Color", text=str(colony.color))
             show_pheromone_label = MDBoxLayout(orientation="horizontal", size_hint=(.75, .75))
             pheromone_grid_label = MDTextField(hint_text="Pheromone grid", text=str(colony.pheromone.pheromone_array[0].shape))
-            pheromone_switch = MDSwitch(icon_active="check")
+            pheromone_switch = PheromoneSwitch(active=colony.show_pheromone)
             show_pheromone_label.add_widget(pheromone_grid_label)
             show_pheromone_label.add_widget(pheromone_switch)
 
@@ -345,6 +347,51 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
             return False
         self.scale = 1
         self.pos = ((self.width - sim.bounds[1])//2, (self.height - sim.bounds[2])//2)
+
+
+class PheromoneSwitch(MDSwitch):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.icon_active = "check"
+
+    def on_active(self, instance_switch, active_value: bool) -> None:
+        if self.theme_cls.material_style == "M3" and self.widget_style != "ios":
+            size = (
+                (
+                    (dp(16), dp(16))
+                    if not self.icon_inactive
+                    else (dp(24), dp(24))
+                )
+                if not active_value
+                else (dp(24), dp(24))
+            )
+            icon = "blank"
+            color = (0, 0, 0, 0)
+
+            if self.icon_active and active_value:
+                icon = self.icon_active
+                color = (
+                    self.icon_active_color
+                    if self.icon_active_color
+                    else self.theme_cls.text_color
+                )
+            elif self.icon_inactive and not active_value:
+                icon = self.icon_inactive
+                color = (
+                    self.icon_inactive_color
+                    if self.icon_inactive_color
+                    else self.theme_cls.text_color
+                )
+
+            if not self.active:
+                Animation(size=size, t="out_quad", d=0.2).start(self.ids.thumb)
+                Animation(color=color, t="out_quad", d=0.2).start(
+                    self.ids.thumb.ids.icon
+                )
+            
+            self.set_icon(self, icon)
+
+        self._update_thumb_pos()
 
 
 class FoodButton(MDFloatingActionButton):

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -265,8 +265,9 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
             color_label = MDTextField(hint_text="Color", text=str(colony.color))
             show_pheromone_label = MDBoxLayout(orientation="horizontal", size_hint=(.5, .5))
             pheromone_grid_label = MDTextField(hint_text="Pheromone grid", text=str(colony.pheromone.pheromone_array[0].shape))
+            pheromone_switch = MDSwitch(icon_active="check")
             show_pheromone_label.add_widget(pheromone_grid_label)
-            show_pheromone_label.add_widget(MDSwitch(icon_active="check"))
+            show_pheromone_label.add_widget(pheromone_switch)
 
             self.dialog = MDDialog(
                 title='Colony Settings',
@@ -288,7 +289,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
                     ),
                     MDFlatButton(
                         text="Apply Changes",
-                        on_release=lambda *args: self.apply_ant_changes(colony, ants_label.text, ant_settings_label.text, carry_label.text, color_label.text, pheromone_grid_label.text)
+                        on_release=lambda *args: self.apply_ant_changes(colony, ants_label.text, ant_settings_label.text, carry_label.text, color_label.text, pheromone_grid_label.text, pheromone_switch.active)
                     ),
                 ],
             )
@@ -318,7 +319,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
         )
         self.dialog.open()
     
-    def apply_ant_changes(self, colony, new_ant_count, new_step_size, new_amount_to_carry, new_color, new_pheromone_grid):
+    def apply_ant_changes(self, colony, new_ant_count, new_step_size, new_amount_to_carry, new_color, new_pheromone_grid, new_pheromone_state):
         new_ant_count = int(new_ant_count)
         new_amount_to_carry = int(new_amount_to_carry)
         new_step_size = int(new_step_size)
@@ -330,6 +331,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
             colony.add_ants(step_size=new_step_size, amount_to_carry=new_amount_to_carry)
             colony.color = new_color
             colony.pheromone = Pheromone(grid_shape=new_pheromone_grid)
+            colony.show_pheromone = new_pheromone_state
             self.dialog.dismiss()
 
     def apply_food_changes(self, food, new_food_amount):

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -205,11 +205,11 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
                 scale = (sim.bounds[1]//pheromone_shape[1], -sim.bounds[2]//pheromone_shape[0])
                 for pheromone_array in (0, 1):
                     array_values = colony.pheromone.pheromone_array[pheromone_array]
+                    alpha = array_values / (np.min(array_values)*1.7+1) if pheromone_array == 0 else array_values / (np.max(array_values)*1.7+1)
+                    color = (0, 0, 0.7) if pheromone_array == 0 else (0.7, 0, 0)
                     for row in range(pheromone_shape[0]):
                         for col in range(pheromone_shape[1]):
-                            alpha = array_values[row, col] / (np.min(array_values)*1.7+1) if pheromone_array == 0 else array_values[row, col] / (np.max(array_values)*1.7+1)
-                            color = (0, 0, 0.7, alpha) if pheromone_array == 0 else (0.7, 0, 0, alpha)
-                            Color(*color)
+                            Color(*color, alpha[row][col])
                             Rectangle(pos=(col*scale[0]+2.5, -row*(scale[1]) - scale[1]+2.5), size=(scale[0], scale[1]))
 
                 Image(source="../images/colony.png", pos=colony.coordinates, size=(100, 100))

--- a/resources/gui.py
+++ b/resources/gui.py
@@ -191,7 +191,7 @@ class SimulationWidget(ResizableDraggablePicture, Widget):
                 max_y - min_y + 5
             ), width=1)
             pos = (min_x, min_y)
-            self.img = Image(source="../images/background.jpg", pos=pos, size=(max_x-min_x+5, max_y-min_y+5), allow_stretch = True, keep_ratio=False)
+            Image(source="../images/background.jpg", pos=pos, size=(max_x-min_x+5, max_y-min_y+5), allow_stretch = True, keep_ratio=False)
 
     def update_canvas(self):
         self.canvas.clear()
@@ -503,7 +503,7 @@ class ButtonWidget(BoxLayout):
             with self.simulation_widget.canvas:
                 Image(source="../images/colony.png", pos=(transformed_touch[0] - 50, transformed_touch[1] - 50), size=(100, 100))
             self.simulation_widget.unbind(on_touch_down=self.place_colony)
-            n_row, n_col = int(sim.bounds[3]-sim.bounds[2])//40, int(sim.bounds[1]-sim.bounds[0])//40   ### /40 for pheromone grid
+            n_row, n_col = int(sim.bounds[3]-sim.bounds[2])//40, int(sim.bounds[1]-sim.bounds[0])//40
             sim.add_colony(Colony(grid_pheromone_shape=(n_row, n_col), amount=100, size=(100, 100),
                                   coordinates=(transformed_touch[0] - 50, transformed_touch[1] - 50), color=(0, 0, 0, 1)))
 


### PR DESCRIPTION
I have improved the design of the popups of the Colony and Food objects. In addition, the pheromones are now displayed as rectangles on the canvas (blue="come from nest", red="come from food"), if activated via the switch in the respective colony popup. This allows the pheromone traces of each colony to be viewed.

[![Image from Gyazo](https://i.gyazo.com/157fd4ba5f0fd498555ca44df6ec1d86.gif)](https://gyazo.com/157fd4ba5f0fd498555ca44df6ec1d86)

[![Image from Gyazo](https://i.gyazo.com/95d85d92435dd2ea2daed403976cb402.gif)](https://gyazo.com/95d85d92435dd2ea2daed403976cb402)

[![Image from Gyazo](https://i.gyazo.com/62e51d02ae43f1bb19331cdebe4e2b7a.png)](https://gyazo.com/62e51d02ae43f1bb19331cdebe4e2b7a)